### PR TITLE
Run makeindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,13 @@ all: dvi
 
 dvi:
 	latex $(FILE)
+	makeindex main
+	latex $(FILE)
 
 ps: dvi
 	dvips $(DVIFILE)
 
 pdf: dvi
-	makeindex main
 	dvipdf -ta4 $(DVIFILE)
 
 booklet: ps


### PR DESCRIPTION
When run **make booklet**. The index page will not be include. 

I don't if there is any smart way :thinking:. So we don't compile the latex 2 times