### PR TITLE
CI: Add automatic compilation of booklet

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,39 @@
+name: LaTeX build
+
+on:
+  push:
+    tags:
+      - "*"
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: texlive/texlive:latest
+    steps:
+      - name: Install prerequisites
+        run: apt-get update && apt-get install -y ghostscript
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Compile the document
+        run: |
+          latex main.tex
+          dvips main.dvi
+          sh ./ps2book.sh main.ps
+          ps2pdf main_book.ps sangbog.pdf
+      - name: Upload document
+        uses: actions/upload-artifact@v2
+        with:
+          name: Sangbog
+          path: sangbog.pdf
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: sangbog.pdf

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Compile the document
         run: |
           latex main.tex
+          makeindex main
+          latex main.tex
           dvips main.dvi
           sh ./ps2book.sh main.ps
           ps2pdf main_book.ps sangbog.pdf


### PR DESCRIPTION
Som opfølging på diskussionerne i #3 og #5 har jeg tilføjet en Github action som compiler sangbogen ved PRs og uploader en compilet version til hvert commit. Når man tagger et release tilføjer den også den compilede version dertil. Se https://github.com/hrjakobsen/sangbog/releases for et eksempel.