### PR TITLE
CI: Add continious pdf file to outputs of CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -27,15 +27,23 @@ jobs:
           makeindex main
           latex main.tex
           dvips main.dvi
+          dvipdf main.dvi kontinuerlig.pdf
           sh ./ps2book.sh main.ps
           ps2pdf main_book.ps sangbog.pdf
-      - name: Upload document
+      - name: Upload songbook (booklet)
         uses: actions/upload-artifact@v2
         with:
           name: Sangbog
           path: sangbog.pdf
+      - name: Upload songbook (continuous)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Kontinuerlig
+          path: kontinuerlig.pdf
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: sangbog.pdf
+          files: |
+            sangbog.pdf
+            kontinuerlig.pdf


### PR DESCRIPTION
Lige nu uploader vi kun sanghæftet i hæfte-format. Dette PR tilføjer så vi også uploader den kontinuerlige PDF version, hvis folk vil læse den på deres digitale device. Det kunne bruges i det tilfælde at der ikke er printet nok hæfter, eller hvis man bare vil læse en sang.