### PR TITLE
Add missing files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ main.aux
 main.idx
 main.log
 main.ind
+main.dvi
+main.ilg
+main.pdf


### PR DESCRIPTION
The .gitignore file now contains all autogenerated files performed by
the two Makefile targets "pdf" and "booklet".