### PR TITLE
0-indexing the sangbog, as it should be

### DIFF
--- a/russb.cls
+++ b/russb.cls
@@ -60,7 +60,7 @@
    }%
 }
 \newcounter{verscnt}
-\newcounter{sangcnt}\setcounter{sangcnt}{0}
+\newcounter{sangcnt}\setcounter{sangcnt}{-1}
 
 \def\@sangtitel#1#2{%
     \begingroup\raggedright\interlinepenalty=10000
@@ -84,7 +84,7 @@
               \addpenalty{-300}%
               \stepcounter{sangcnt}
               \index{#1}%
-              \setcounter{verscnt}{0}%
+              \setcounter{verscnt}{-1}%
               \@lastversdoublefalse
               \@fulberthack{#1}
               \@sangtitel{#1}{#2}%


### PR DESCRIPTION
i think it might be a good idea to add a new song at index 0 so the song indices are consistent with previous versions, though it would also mess with which page each song is on. For example, song 7 will now be song 6, but it will still be on page 17, but if another song is added at index 0, song 7 will be moved to page 18 or 19.

some comments changed even with editing on github, might be an encoding issue?