### PR TITLE
Improve flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ nix develop
 ```sh
 make booklet
 ```
+Or build and run the latest version locally: `nix run github:f-klubben/sangbog`
 
 Adding new songs
 -------------

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ Building using nix
 -------------
 For nix based systems with flakes enabled:
 1. Fetch the source code
-  ```sh 
-  git clone https://github.com/f-klubben/sangbog.git
-  ```
+```sh 
+git clone https://github.com/f-klubben/sangbog.git
+```
 2. Enter environment
 ```sh
-  nix develop
+nix develop
 ```
 3. Build pdf
 ```sh
-   make booklet
+make booklet
 ```
 
 Adding new songs

--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,8 @@
             installPhase = ''
                 mkdir -p $out/{bin,share}
                 ${pkgs.gnumake}/bin/make pdf
-                mv main_book.pdf $out/share
-                echo "${pkgs.xdg-utils}/bin/xdg-open $out/share/main_book.pdf" > $out/bin/${builtins.replaceStrings [" "] ["-"] name}
+                mv main.pdf $out/share
+                echo "${pkgs.xdg-utils}/bin/xdg-open $out/share/main.pdf" > $out/bin/${builtins.replaceStrings [" "] ["-"] name}
                 chmod +x $out/bin/${builtins.replaceStrings [" "] ["-"] name}
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,22 +9,28 @@
         system = "x86_64-linux";
         pkgs = import nixpkgs {inherit system;};
         deps = with pkgs; [ ghostscript texliveFull psutils gnumake which perl ];
-        booklet = pkgs.stdenv.mkDerivation {
+        booklet = pkgs.stdenv.mkDerivation rec {
             name = "F-klubbens sangbog booklet";
             src = ./.;
             nativeBuildInputs = deps;
             installPhase = ''
+                mkdir -p $out/{bin,share}
                 ${pkgs.gnumake}/bin/make booklet
-                mv main_book.pdf $out
+                mv main_book.pdf $out/share
+                echo "${pkgs.xdg-utils}/bin/xdg-open $out/share/main_book.pdf" > $out/bin/${builtins.replaceStrings [" "] ["-"] name}
+                chmod +x $out/bin/${builtins.replaceStrings [" "] ["-"] name}
             '';
         };
-        pdf = pkgs.stdenv.mkDerivation {
+        pdf = pkgs.stdenv.mkDerivation rec{
             name = "F-klubbens sangbog continuous";
             src = ./.;
             nativeBuildInputs = deps;
             installPhase = ''
+                mkdir -p $out/{bin,share}
                 ${pkgs.gnumake}/bin/make pdf
-                mv main_book.pdf $out
+                mv main_book.pdf $out/share
+                echo "${pkgs.xdg-utils}/bin/xdg-open $out/share/main_book.pdf" > $out/bin/${builtins.replaceStrings [" "] ["-"] name}
+                chmod +x $out/bin/${builtins.replaceStrings [" "] ["-"] name}
             '';
 
         };
@@ -37,6 +43,7 @@
         packages.${system} = {
             default = booklet; 
             pdf = pdf;
+            booklet = booklet;
         };
 
     };


### PR DESCRIPTION
improved functionality of the nix flake:

* `nix build github:f-klubben/sangbog` 
builds the booklet
* `nix build github:f-klubben/sangbog#pdf`
builds the continuous pdf

build output is available at `./result/share/main_book.pdf`

* `nix run github:f-klubben/sangbog`
builds and opens the booklet in any program capable of displaying PDF (xdg-open) without having to clone the project (works kinda like a from-source release for nix users)