### PR TITLE
CI: Use make and don't use a container

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,22 +14,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: texlive/texlive:latest
     steps:
       - name: Install prerequisites
-        run: apt-get update && apt-get install -y ghostscript
+        run: sudo apt-get update && sudo apt-get install -y texlive-latex-extra ghostscript psutils
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Compile the document
         run: |
-          latex main.tex
-          makeindex main
-          latex main.tex
-          dvips main.dvi
-          dvipdf main.dvi kontinuerlig.pdf
-          sh ./ps2book.sh main.ps
-          ps2pdf main_book.ps sangbog.pdf
+          make pdf
+          make booklet
+          mv main.pdf kontinuerlig.pdf
+          mv main_book.pdf sangbog.pdf
       - name: Upload songbook (booklet)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The make file is how we compile this stuff locally. So the CI should do the same. Now, if the make file is broken the CI fails :) Also containers are cringe. Use ubuntus package manager instead. This reduces the build time with ~1 minute.

This is a fixed version of #35